### PR TITLE
Remove 24h cap on elapsed time display, show days when applicable

### DIFF
--- a/Ciga Watch App/Views/TrackerView.swift
+++ b/Ciga Watch App/Views/TrackerView.swift
@@ -9,6 +9,29 @@ import Foundation
 import SwiftUI
 import SwiftData
 
+private struct ElapsedTimerText: View {
+    let startDate: Date
+
+    var body: some View {
+        TimelineView(.periodic(from: startDate, by: 1.0)) { context in
+            Text(format(elapsed: max(0, context.date.timeIntervalSince(startDate))))
+                .monospacedDigit()
+        }
+    }
+
+    private func format(elapsed: TimeInterval) -> String {
+        let total = Int(elapsed)
+        let days = total / 86400
+        let hours = (total % 86400) / 3600
+        let minutes = (total % 3600) / 60
+        let seconds = total % 60
+        if days > 0 {
+            return String(format: "%dd %02d:%02d:%02d", days, hours, minutes, seconds)
+        }
+        return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+    }
+}
+
 struct TrackerView: View {
     var inhales: [Inhale]
     var showInhales: Bool
@@ -31,7 +54,7 @@ struct TrackerView: View {
                         .foregroundColor(.accentColor)
                     
                     let lastInhale = cigaInhales.max(by: { $0.smokeDate < $1.smokeDate })
-                    Text(timerInterval: (lastInhale?.smokeDate ?? Date())...((lastInhale?.smokeDate ?? Date()).addingTimeInterval(60*60*24)), countsDown: false, showsHours: false)
+                    ElapsedTimerText(startDate: lastInhale?.smokeDate ?? Date())
                         .foregroundColor(.secondary)
                 }
                 .frame(width: geometry.size.width / 2, alignment: .center)

--- a/Ciga iOS App/Views/TrackerView.swift
+++ b/Ciga iOS App/Views/TrackerView.swift
@@ -1,6 +1,29 @@
 import SwiftUI
 import SwiftData
 
+private struct ElapsedTimerText: View {
+    let startDate: Date
+
+    var body: some View {
+        TimelineView(.periodic(from: startDate, by: 1.0)) { context in
+            Text(format(elapsed: max(0, context.date.timeIntervalSince(startDate))))
+                .monospacedDigit()
+        }
+    }
+
+    private func format(elapsed: TimeInterval) -> String {
+        let total = Int(elapsed)
+        let days = total / 86400
+        let hours = (total % 86400) / 3600
+        let minutes = (total % 3600) / 60
+        let seconds = total % 60
+        if days > 0 {
+            return String(format: "%dd %02d:%02d:%02d", days, hours, minutes, seconds)
+        }
+        return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+    }
+}
+
 struct iOSTrackerView: View {
     var inhales: [Inhale]
     var showInhales: Bool
@@ -36,8 +59,7 @@ struct iOSTrackerView: View {
                     .foregroundColor(.secondary)
 
                 if let last = lastCigaDate {
-                    Text(timerInterval: last...last.addingTimeInterval(86400),
-                         countsDown: false, showsHours: true)
+                    ElapsedTimerText(startDate: last)
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }


### PR DESCRIPTION
Replaces SwiftUI's Text(timerInterval:) — which was artificially capped
at 86400s — with a custom ElapsedTimerText view backed by TimelineView.
The timer now counts indefinitely: under 24h it shows HH:mm:ss, at 24h+
it switches to Xd HH:mm:ss (e.g. "2d 03:45:12"). Applied to both the
Watch and iPhone tracker views.

https://claude.ai/code/session_01MBXYVRdvco8LR8m8WP4bg5